### PR TITLE
Support multiple comma-separated websites in the website string

### DIFF
--- a/src/components/Card/CardBody.js
+++ b/src/components/Card/CardBody.js
@@ -6,83 +6,32 @@ import Actions from '~/state/Actions';
 
 import CardParagraph from './CardParagraph';
 import CardTags from './CardTags';
-import CardLink from './CardLink';
+import CardLinks from './CardLinks';
 import CardLogo from './CardLogo';
 import CategoryLabel from '../CategoryLabel';
-
-const CardParagraphAddress = styled(CardParagraph)``;
-const CardParagraphWebsite = styled(CardParagraph)``;
 
 const CardBodyWrapper = styled.div`
   font-size: ${props => props.theme.fontSizes[0]};
 `;
 
-const CardBodySection = styled.div`
-  display: flex;
-  margin-bottom: 10px;
-`;
-
-const CardSectionLeft = styled.div`
-  margin-right: 10px;
-  min-width: 35%;
-  width: 35%;
-`;
-
-const CardSectionRight = styled.div`
-  margin-left: auto;
-  text-align: right;
-  flex-grow: 1;
-`;
-
-const Description = styled.div`
-  border-bottom: 1px solid #ddd;
-  padding-bottom: 10px;
-`;
-
-const WebsiteLinkContainer = styled(CardSectionRight)`
-  overflow: hidden;
-  width: 100%;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-
-  a {
-    font-weight: 400;
-  }
-`;
-
-function formatWebsite(str) {
-  if (!str) {
-    return '';
-  }
-
-  return str
-    .toLowerCase()
-    .replace(/https?:\/\//, '')
-    .replace(/www\./, '')
-    .replace(/\/$/, '');
-}
-
-
 class CardBody extends PureComponent {
   render() {
-    const { data, targetGroups, favs, toggleFav } = this.props;
+    const { data } = this.props;
     const logoUrl = idx(data, _ => _.logo[0].url);
-    const website = idx(data, _ => _.contact[0].website);
-    const address = idx(data, _ => _.contact[0].address);
+    const websiteString = idx(data, _ => _.contact[0].website);
+    const websitesArray = websiteString ? websiteString.split(',') : []
     const email = idx(data, _ => _.contact[0].email);
     const phone = idx(data, _ => _.contact[0].phone);
     const openingHours = idx(data, _ => _.contact[0].openinghours);
     const category = idx(data, _ => _.category);
-
-    const isFav = favs.includes(data.autoid);
 
     return (
       <CardBodyWrapper className={this.props.className}>
         { category && <CategoryLabel label='Leistungsangebot:' category={category}></CategoryLabel> }
         { logoUrl && <CardLogo label='Logo:' data={logoUrl}></CardLogo> }
         <CardParagraph type="bold" label='Adresse:' data={data.location[0].address}></CardParagraph>
-        { website && <CardLink label='Webseite:' data={website}></CardLink> }
-        { email && <CardLink type="mailto:" label='E-Mail:' data={email}></CardLink> }
+        { websitesArray.length > 0 && <CardLinks label='Webseite:' links={websitesArray}></CardLinks> }
+        { email && <CardLinks type="mailto:" label='E-Mail:' links={[email]}></CardLinks> }
         { phone && <CardParagraph type="bold" label='Telefon:' data={phone}></CardParagraph> }
         { openingHours && <CardParagraph type="bold" label='Öffnungszeiten:' data={openingHours}></CardParagraph> }
         <CardParagraph label='Beschreibung:' data={data.description}></CardParagraph>

--- a/src/components/Card/CardLinks.js
+++ b/src/components/Card/CardLinks.js
@@ -23,16 +23,22 @@ const CardParagraphWrapper = styled.div`
   }
 `;
 
-function formatWebsite(str) {
-  if (!str) {
-    return '';
-  }
-
-  return str
+function formatLink(link) {
+  return link
     .toLowerCase()
     .replace(/https?:\/\//, '')
     .replace(/www\./, '')
     .replace(/\/$/, '');
+}
+
+function getHref(type, link) {
+  if (type === 'mailto:') {
+    return `mailto:${link}`
+  }
+  if (!link.startsWith('http')) {
+    return 'https://' + link
+  }
+  return link
 }
 
 class CardLinks extends PureComponent {
@@ -42,8 +48,8 @@ class CardLinks extends PureComponent {
       <CardParagraphWrapper>
         <span>{label}</span>
         {links.map(link => (
-          <WebsiteLink key={link} href={type === 'mailto:' ? `mailto:${link}` : link} target="_blank" rel="noopener">
-            <h3>{formatWebsite(link)}</h3>
+          <WebsiteLink key={link} href={getHref(type, link)} target="_blank" rel="noopener">
+            <h3>{formatLink(link)}</h3>
           </WebsiteLink>
         ))}
       </CardParagraphWrapper>

--- a/src/components/Card/CardLinks.js
+++ b/src/components/Card/CardLinks.js
@@ -35,29 +35,20 @@ function formatWebsite(str) {
     .replace(/\/$/, '');
 }
 
-class CardParagraph extends PureComponent {
+class CardLinks extends PureComponent {
   render() {
-    const { label, data, type } = this.props;
-    if (data.length > 0) {
-      return (
-        <CardParagraphWrapper>
-          <span>{label}</span>
-          { type == 'mailto:' && 
-            (<WebsiteLink href={`mailto:${data}`} target="_blank" rel="noopener">
-              <h3>{formatWebsite(data)}</h3>
-            </WebsiteLink>)
-          }
-          { type != 'mailto:' && 
-            (<WebsiteLink href={`${data}`} target="_blank" rel="noopener">
-              <h3>{formatWebsite(data)}</h3>
-            </WebsiteLink>)
-          }
-        </CardParagraphWrapper>
-      )
-    } else {
-      return (null)
-    }
+    const { label, links, type } = this.props;
+    return (
+      <CardParagraphWrapper>
+        <span>{label}</span>
+        {links.map(link => (
+          <WebsiteLink key={link} href={type === 'mailto:' ? `mailto:${link}` : link} target="_blank" rel="noopener">
+            <h3>{formatWebsite(link)}</h3>
+          </WebsiteLink>
+        ))}
+      </CardParagraphWrapper>
+    )
   }
 }
 
-export default CardParagraph;
+export default CardLinks;

--- a/src/modules/Map/MapViews/FilterView.js
+++ b/src/modules/Map/MapViews/FilterView.js
@@ -13,7 +13,7 @@ class FilterView extends PureComponent {
   }
 
   render() {
-    const { data, detailData, isLoading, labels } = this.props;
+    const { data, isLoading } = this.props;
 
     if (data) {
       return (


### PR DESCRIPTION
Das `website`-Feld in `institutions.json` hat teilweise mehrere kommagetrennte Werte. Beispiel:

```
"website": "https://learnattack.de/,https://learnattack.de/magazin/,https://de-de.facebook.com/learnattack/,https://learnattack.de/journal/",
```

Bisher wurden dadurch kaputte Links erstellt. Mit dem PR werden diese Fälle richtig geparst und als mehrere Links dargestellt. Außerdem funktionieren jetzt auch die Links, die kein Protokoll (`http`) enthalten.

![Bildschirmfoto 2023-06-22 um 18 26 46](https://github.com/technologiestiftung/edutech-map/assets/6429568/3333c710-6b23-44a9-89a0-b2978f60b884)
