### PR TITLE
Fix CI build by removing $ in .env

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"version": "6.0.1",
 	"description": "lightweight react starterkit including webpack, unistore, styled components",
 	"scripts": {
-		"build:ci": "echo \"$MAP_STYLE=$MAP_STYLE\" > .env && echo \"$MAP_TOKEN=$MAP_TOKEN\" >> .env &&  BABEL_ENV=production webpack --config webpack/webpack.config.prod.js",
+		"build:ci": "echo \"MAP_STYLE=$MAP_STYLE\" > .env && echo \"MAP_TOKEN=$MAP_TOKEN\" >> .env &&  BABEL_ENV=production webpack --config webpack/webpack.config.prod.js",
 		"build": "BABEL_ENV=production webpack --config webpack/webpack.config.prod.js",
 		"start": "webpack-dev-server --config webpack/webpack.config.dev.js",
 		"lint": "eslint --ext .js --ext .jsx ."


### PR DESCRIPTION
Removes unneeded $ prefix to fix the format of variables in the `.env` file.